### PR TITLE
Hometask:04.Vagrant

### DIFF
--- a/aakhrymenko/04.Vagrant/Homework.04.Vagrant.md
+++ b/aakhrymenko/04.Vagrant/Homework.04.Vagrant.md
@@ -1,0 +1,31 @@
+# 04.Vagrant
+## Vagrant Boxes 
+https://app.vagrantup.com/andreymailmail/boxes/test1-debian
+https://app.vagrantup.com/andreymailmail/boxes/test2-centos
+
+## Vagrantfile
+
+```ruby
+
+Vagrant.configure("2") do |config|
+  config.vm.define "Debian10" do |debian|
+    debian.vm.box = "generic/debian10"
+    end
+    debian.vm.provision "shell", inline: <<-SHELL
+      useradd -m -g vagrant updater
+      echo updater:vagrant | chpasswd
+      apt-get install vim git wget curl -yqq
+    SHELL
+  end
+  config.vm.define "Centos8" do |centos|
+    centos.vm.box = "centos/8"
+    end
+    centos.vm.provision "shell", inline: <<-SHELL
+      useradd -g vagrant updater
+      echo vagrant | passwd --stdin updater
+      yum install vim git wget curl -yqq
+    SHELL
+  end
+end
+
+```


### PR DESCRIPTION
Can't UP vagrant on Windows10
$ vagrant.exe up
Vagrant failed to initialize at a very early stage:

There is a syntax error in the following Vagrantfile. The syntax error
message is reproduced below for convenience:

F:/Git/test_repo/04.Vagrant/test/Vagrantfile:19: syntax error, unexpected end, expecting end-of-input
  end
  ^~~

