### PR TITLE
Homework 21: Jenkins Docker and Pod

### DIFF
--- a/antonzhdanko/21.Jenkins.Docker.Pod/README.md
+++ b/antonzhdanko/21.Jenkins.Docker.Pod/README.md
@@ -1,0 +1,69 @@
+# Homework 21: Jenkins Docker and Pod
+
+## Source repository
+
+The application and pipeline sources are stored in
+[`sa2-35-26-jenkins/pipeline-app`](https://github.com/antonzhdanko/sa2-35-26-jenkins/tree/main/pipeline-app):
+
+- [`Dockerfile`](https://github.com/antonzhdanko/sa2-35-26-jenkins/blob/main/pipeline-app/Dockerfile);
+- [`index.html`](https://github.com/antonzhdanko/sa2-35-26-jenkins/blob/main/pipeline-app/index.html);
+- [`Jenkinsfile`](https://github.com/antonzhdanko/sa2-35-26-jenkins/blob/main/pipeline-app/Jenkinsfile).
+
+The application uses an unprivileged Nginx image and listens on port `8080`.
+The Dockerfile contains a container health check.
+
+## Pipeline
+
+The Jenkins job `docker-pod-pipeline` loads the Jenkinsfile from the `main`
+branch and creates a temporary Kubernetes agent Pod. The Pod contains separate
+containers for Docker CLI, Docker-in-Docker, Hadolint, kubectl and the Jenkins
+inbound agent.
+
+Pipeline stages:
+
+1. `Checkout code` checks out the source repository.
+2. `Validate Dockerfile` runs Hadolint.
+3. `Build image` builds the application image with Docker.
+4. `Test image` runs the built image locally and checks its WebUI over HTTP.
+5. `Push image` publishes the tested image to
+   `jfrog.it-academy.by/public/jenkins-routine-app`.
+6. `Deploy pre-prod` creates a Deployment and Service in `pre-prod`, waits for
+   rollout and tests the Service from a temporary curl Pod.
+7. `Approve production` pauses the build in Jenkins WebUI. Build 5 was manually
+   approved by `admin` only after the pre-production test succeeded.
+8. `Deploy prod` deploys the same immutable image tag to `prod`, waits for
+   rollout and repeats the internal HTTP test.
+9. `Clean pre-prod` removes the pre-production Deployment and Service.
+
+The `post` section always sends a colour-coded Slack notification and performs
+an idempotent pre-production cleanup. The successful notification returned
+`ok` from Slack.
+
+## Security and deployment
+
+- JFrog Docker credentials are mounted from a `kubernetes.io/dockerconfigjson`
+  Secret and are stored in Git only as a SealedSecret.
+- The Slack webhook is provided to Jenkins as a masked string credential and
+  is also stored only as a SealedSecret.
+- The Jenkins ServiceAccount has namespace-scoped Roles only in `pre-prod` and
+  `prod`; it does not receive cluster-admin rights.
+- No password, registry auth data, Slack URL, kubeconfig or private key is
+  committed.
+
+## Result
+
+Jenkins build 5 completed with `SUCCESS`:
+
+- Hadolint passed;
+- local container WebUI test passed;
+- image tag `5` was pushed to JFrog;
+- pre-production rollout and HTTP test passed;
+- manual approval was recorded as `Approved by admin`;
+- production rollout and HTTP test passed;
+- `pre-prod` was cleaned;
+- `prod` remains `1/1 Running` with image tag `5`;
+- Slack notification succeeded.
+
+The exported Jenkins job XML is available in
+[`docker-pod-pipeline-config.xml`](docker-pod-pipeline-config.xml). Verification
+output is saved in [`evidence`](evidence/).

--- a/antonzhdanko/21.Jenkins.Docker.Pod/docker-pod-pipeline-config.xml
+++ b/antonzhdanko/21.Jenkins.Docker.Pod/docker-pod-pipeline-config.xml
@@ -1,0 +1,49 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<flow-definition plugin="workflow-job@1590.v49101d088542">
+  <actions>
+    <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction plugin="pipeline-model-definition@2.2291.v2934911987b_6"/>
+    <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction plugin="pipeline-model-definition@2.2291.v2934911987b_6">
+      <jobProperties>
+        <string>jenkins.model.BuildDiscarderProperty</string>
+      </jobProperties>
+      <triggers/>
+      <parameters/>
+      <options/>
+    </org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction>
+  </actions>
+  <description>Build, test, publish and promote the Homework 21 application</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>-1</daysToKeep>
+        <numToKeep>10</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
+        <removeLastBuild>false</removeLastBuild>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+  </properties>
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@4350.vcc65d4958821">
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@5.10.1">
+      <configVersion>2</configVersion>
+      <userRemoteConfigs>
+        <hudson.plugins.git.UserRemoteConfig>
+          <url>https://github.com/antonzhdanko/sa2-35-26-jenkins.git</url>
+        </hudson.plugins.git.UserRemoteConfig>
+      </userRemoteConfigs>
+      <branches>
+        <hudson.plugins.git.BranchSpec>
+          <name>*/main</name>
+        </hudson.plugins.git.BranchSpec>
+      </branches>
+      <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+      <gitTool>Default</gitTool>
+      <extensions/>
+    </scm>
+    <scriptPath>pipeline-app/Jenkinsfile</scriptPath>
+    <lightweight>false</lightweight>
+  </definition>
+  <triggers/>
+  <disabled>false</disabled>
+</flow-definition>

--- a/antonzhdanko/21.Jenkins.Docker.Pod/evidence/cluster-state.txt
+++ b/antonzhdanko/21.Jenkins.Docker.Pod/evidence/cluster-state.txt
@@ -1,0 +1,27 @@
+Argo CD:
+jenkins-homework: chart 0.1.7, Synced, Healthy
+
+Jenkins agent:
+The temporary five-container Kubernetes agent Pod completed and was removed.
+
+Production:
+namespace: prod
+deployment: jenkins-pipeline-app
+ready: 1/1
+image: jfrog.it-academy.by/public/jenkins-routine-app:5
+pod status: Running
+restarts: 0
+
+Pre-production after cleanup:
+namespace: pre-prod
+deployments: none
+services: none
+pods: none
+
+Secrets:
+jenkins-registry: kubernetes.io/dockerconfigjson, generated from SealedSecret
+jenkins-slack: Opaque, generated from SealedSecret
+
+RBAC:
+Jenkins has namespace-scoped jenkins-deployer Roles in pre-prod and prod.
+No cluster-admin role was granted to the Jenkins ServiceAccount.

--- a/antonzhdanko/21.Jenkins.Docker.Pod/evidence/pipeline-build-5.txt
+++ b/antonzhdanko/21.Jenkins.Docker.Pod/evidence/pipeline-build-5.txt
@@ -1,0 +1,19 @@
+Jenkins job: docker-pod-pipeline
+Build: 5
+Source revision: d9f1087c6061c33431a03bd5ab1b366cadd0d14c
+
+Checkout code: SUCCESS
+Dockerfile validation: hadolint Dockerfile - SUCCESS
+Docker build: jfrog.it-academy.by/public/jenkins-routine-app:5
+Local WebUI test: SUCCESS
+Registry push digest: sha256:4110dee6912988278fda735125a82ffd1dd9c84ccfcc80b5109308951535c7ca
+Pre-production rollout: SUCCESS
+Pre-production HTTP test: SUCCESS
+Manual gate: Approved by admin
+Production rollout: SUCCESS
+Production HTTP test: SUCCESS
+Pre-production Service deleted: SUCCESS
+Pre-production Deployment deleted: SUCCESS
+Slack notification response: ok
+
+Finished: SUCCESS


### PR DESCRIPTION
## Homework 21

- added an application Dockerfile, WebUI and declarative Jenkinsfile
- validated the Dockerfile with Hadolint
- built and tested the image with Docker-in-Docker
- pushed the tested image to JFrog
- deployed and tested the application in pre-prod
- used a manual Jenkins approval before production
- deployed and tested the same image in prod
- cleaned all pre-prod resources
- sent a successful Slack notification
- stored registry and Slack credentials only as SealedSecrets
- included exported job XML and successful build evidence

Final Jenkins build: #5 SUCCESS.